### PR TITLE
Fix function argument for C23

### DIFF
--- a/src/lxinput.c
+++ b/src/lxinput.c
@@ -81,7 +81,7 @@ static void on_kb_range_changed(GtkRange* range, int* val)
 
 /* This function is taken from Gnome's control-center 2.6.0.3 (gnome-settings-mouse.c) and was modified*/
 #define DEFAULT_PTR_MAP_SIZE 128
-static void set_left_handed_mouse()
+static void set_left_handed_mouse(void)
 {
     unsigned char *buttons;
     gint n_buttons, i;
@@ -115,7 +115,7 @@ static void set_left_handed_mouse()
 static void on_left_handed_toggle(GtkToggleButton* btn, gpointer user_data)
 {
     left_handed = gtk_toggle_button_get_active(btn);
-    set_left_handed_mouse(left_handed);
+    set_left_handed_mouse();
 }
 
 static void on_kb_beep_toggle(GtkToggleButton* btn, gpointer user_data)


### PR DESCRIPTION
C23 regards function prototype with no parameter list as that with taking no parameter (i.e. `func(void)`). Explicitly write `void` for parameter list of
set_left_handed_mouse() for C23.

In set_left_handed_mouse(), left_handed variable is taken from global, so no need to pass it to the argument. Also, main() calls set_left_handed_mouse() with no parameter. Remove parameter when calling set_left_handed_mouse() in on_left_handed_toggle().