### PR TITLE
Add MATE to NotShowIn for LXInput autostart

### DIFF
--- a/data/lxinput.desktop.in
+++ b/data/lxinput.desktop.in
@@ -7,4 +7,4 @@ _Comment=Configure keyboard, mouse, and other input devices
 StartupNotify=true
 Terminal=false
 Categories=GTK;Settings;HardwareSettings;X-LXDE-Settings;
-NotShowIn=GNOME;KDE;XFCE;MATE;
+NotShowIn=GNOME;KDE;XFCE;MATE;Budgie;COSMIC;Enlightenment;LXQt;X-Cinnamon;

--- a/src/lxinput.c
+++ b/src/lxinput.c
@@ -350,7 +350,7 @@ int main(int argc, char** argv)
                                   "Comment=%s\n"
                                   "NoDisplay=true\n"
                                   "Exec=sh -c 'xset m %d/10 %d r rate %d %d b %s%s'\n"
-                                  "NotShowIn=GNOME;KDE;XFCE;\n",
+                                  "NotShowIn=GNOME;KDE;XFCE;MATE;\n",
                                   _("LXInput autostart"),
                                   _("Setup keyboard and mouse using settings done in LXInput"),
                                   /* FIXME: how to setup left-handed mouse? */

--- a/src/lxinput.c
+++ b/src/lxinput.c
@@ -350,7 +350,7 @@ int main(int argc, char** argv)
                                   "Comment=%s\n"
                                   "NoDisplay=true\n"
                                   "Exec=sh -c 'xset m %d/10 %d r rate %d %d b %s%s'\n"
-                                  "NotShowIn=GNOME;KDE;XFCE;MATE;\n",
+                                  "NotShowIn=GNOME;KDE;XFCE;MATE;Budgie;COSMIC;Enlightenment;LXQt;X-Cinnamon;\n",
                                   _("LXInput autostart"),
                                   _("Setup keyboard and mouse using settings done in LXInput"),
                                   /* FIXME: how to setup left-handed mouse? */


### PR DESCRIPTION
The launcher is already hidden in MATE since commit 2b52f014c63cca1581612ea7777a6d552187bdee.

Also, exclude some more desktop environments have their own tools to configure the keyboard and mouse.